### PR TITLE
Bootfold

### DIFF
--- a/vulcanai/models/basenetwork.py
+++ b/vulcanai/models/basenetwork.py
@@ -749,6 +749,8 @@ class BaseNetwork(nn.Module):
             data_loader : torch.utils.data.DataLoader
                 The DataLoader object containing the totality of the data to use
                 for k-fold cross validation.
+            n_samples : int
+                number of times to randomly sample w/ replacement the data_loader and perform boot_cv
             k : int
                 The number of folds to split the training into.
             epochs : int

--- a/vulcanai/models/basenetwork.py
+++ b/vulcanai/models/basenetwork.py
@@ -734,6 +734,72 @@ class BaseNetwork(nn.Module):
             **kwargs
         )
 
+    def bootfold_p_estimate(self, data_loader, n_samples, k, epochs, 
+                            index_to_iter, ls_feat_vals, retain_graph=None,
+                            valid_interv=4, plot=False, save_path=None,
+                            transform_outputs=False, transform_callable=None, p_output_path = None,
+			    **kwargs):
+        """
+	Performs bootfold - estimation to identify whether training model provides statistically significant
+	difference in predicting various values for a given feature when predicting outcome. 
+
+	Parameters:
+	    network : BaseNetwork
+                Network descendant of BaseNetwork.
+            data_loader : torch.utils.data.DataLoader
+                The DataLoader object containing the totality of the data to use
+                for k-fold cross validation.
+            k : int
+                The number of folds to split the training into.
+            epochs : int
+                The number of epochs to train the network per fold.
+	    index_to_iter : string
+		Index of feature within data_loader who's values will be iterated to assess difference
+	    ls_feat_vals : list
+		List of values for feature provided in feat_to_iter
+            valid_interv : int
+                Specifies after how many epochs validation should occur.
+            plot : boolean
+                Whether or not to plot all results in prompt and charts.
+            save_path : str
+                Where to save all figures and results.
+            transform_outputs : boolean
+                Not used in the multi-class case.
+                If true, transform outputs using metrics.transform_outputs.
+                If no transform_callable is provided then the defaults in
+                metrics.transform_outputs will be used: class converstion for
+                one-hot encoded, and identity for one-dimensional outputs.
+                Multiple class multiple outputs are not yet supported.
+            transform_callable: callable
+                Not used in the multi-class case.
+                Used to transform values if transform_outputs is true,
+                otherwise defaults in metrics.transform_outputs will be used.
+                An example could be np.round
+	    p_output_path = str
+		Output file to save p_value to
+            kwargs: dict of keyworded parameters
+                Values passed to transform callable (function parameters)
+
+	Returns:
+	    p_value : float
+        """
+        return self.metrics.bootfold_p_estimate(
+            network=self,
+            data_loader=data_loader,
+            n_samples=n_samples,
+            k=k,
+            epochs=epochs,
+            index_to_iter=index_to_iter,
+            ls_feat_vals=ls_feat_vals,
+            retain_graph=retain_graph,
+            valid_interv=valid_interv,
+            plot=plot,
+            save_path=save_path,
+            transform_outputs=transform_outputs,
+            transform_callable=transform_callable,
+            p_output_path=p_output_path,
+            **kwargs)
+
     def cross_validate(self, data_loader, k, epochs,
                        average_results=True, retain_graph=None,
                        valid_interv=4, plot=False, save_path=None,

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -805,13 +805,8 @@ class Metrics(object):
 
         tot_num_imprv = float(len(ls_imprv_scores))
         score_abv_zero = 0.0
-        score_blw_zero = 0.0
-        for val in ls_imprv_scores:
-            if val > 1.0:
-                score_abv_zero += 1.0
-            else:
-                score_blw_zero += 1.0
-        p_val = float(float(score_abv_zero)/float(score_blw_zero))
+        score_avc_zero = sum(val > 1.0 for val in ls_imprv_scores)
+        p_val = float(score_abv_zero)/float(tot_num_imprv)
 
         with open(p_output_path, 'w') as p_file:
             to_write = str("P value: {}".format(p_val))

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -757,6 +757,8 @@ class Metrics(object):
             data_loader : torch.utils.data.DataLoader
                 The DataLoader object containing the totality of the data to use
                 for k-fold cross validation.
+            n_samples : int
+                Number of samples to be taken and ran through bootfold cv
             k : int
                 The number of folds to split the training into.
             epochs : int
@@ -765,8 +767,6 @@ class Metrics(object):
                 Name of feature within data_loader who's values will be iterated to assess difference
             ls_feat_vals : list
                 List of values for feature provided in index_to_iter
-            average_results : boolean
-                Whether or not to return results from all folds or just an average.
             retain_graph : {None, boolean}
                 Whether retain_graph will be true when .backwards is called.
             valid_interv : int
@@ -832,6 +832,12 @@ class Metrics(object):
                 The number of folds to split the training into.
             epochs : int
                 The number of epochs to train the network per fold.
+            retain_graph : {None, boolean}
+                Whether retain_graph will be true when .backwards is called.
+            valid_interv : int
+                Specifies after how many epochs validation should occur.
+            plot : boolean
+                Whether or not to plot all results in prompt and charts.
 	    index_to_iter : string
                 Index of feature within data_loader who's values will be iterated to assess difference
             ls_feat_vals : list

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -801,8 +801,7 @@ class Metrics(object):
             ls_imprv_scores.append(imprv_score)
 
         tot_num_imprv = float(len(ls_imprv_scores))
-        score_abv_zero = 0.0
-        score_avc_zero = sum(val > 1.0 for val in ls_imprv_scores)
+        score_abv_zero = sum(val > 1.0 for val in ls_imprv_scores)
         p_val = float(score_abv_zero)/float(tot_num_imprv)
 
         logger.info("P value for bootfold p estimate: %d.", p_val)

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -745,8 +745,7 @@ class Metrics(object):
     def bootfold_p_estimate(network, data_loader, n_samples, k, epochs,
 			    index_to_iter, ls_feat_vals, 
 			    retain_graph=None, valid_interv=4, plot=False, 
-                            save_path=None, transform_outputs=False, transform_callable=None,
-			    p_output_path=None, **kwargs):
+                            save_path=None, transform_outputs=False, transform_callable=None, **kwargs):
         """
         Performs bootfold - estimation to identify whether training model provides statistically significant
         difference in predicting various values for a given feature when predicting outcome.
@@ -758,7 +757,7 @@ class Metrics(object):
                 The DataLoader object containing the totality of the data to use
                 for k-fold cross validation.
             n_samples : int
-                Number of samples to be taken and ran through bootfold cv
+                number of times to randomly sample w/ replacement the data_loader and perform boot_cv
             k : int
                 The number of folds to split the training into.
             epochs : int
@@ -787,8 +786,6 @@ class Metrics(object):
                 Used to transform values if transform_outputs is true,
                 otherwise defaults in metrics.transform_outputs will be used.
                 An example could be np.round
-            p_output_path = str
-                Output file to save p_value to
             kwargs: dict of keyworded parameters
                 Values passed to transform callable (function parameters)
 
@@ -808,10 +805,7 @@ class Metrics(object):
         score_avc_zero = sum(val > 1.0 for val in ls_imprv_scores)
         p_val = float(score_abv_zero)/float(tot_num_imprv)
 
-        with open(p_output_path, 'w') as p_file:
-            to_write = str("P value: {}".format(p_val))
-            p_file.write(to_write)
-		
+        logger.info("P value for bootfold p estimate: %d.", p_val)
 
     def boot_cv(network, data_loader, k, epochs, retain_graph, valid_interv, save_path, plot, index_to_iter, ls_feat_vals):
         """

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -811,7 +811,6 @@ class Metrics(object):
                 score_abv_zero += 1.0
             else:
                 score_blw_zero += 1.0
-        import pdb; pdb.set_trace()
         p_val = float(float(score_abv_zero)/float(score_blw_zero))
 
         with open(p_output_path, 'w') as p_file:
@@ -896,7 +895,6 @@ class Metrics(object):
             ls_pos_rate = [subj for subj in data_loader.dataset if subj[1].item() == 1]
             V_t = float(len(ls_pos_rate)/len(data_loader.dataset)) * 100
             improvement_score = float(V_p/V_t)
-            import pdb; pdb.set_trace()
             if np.isnan(improvement_score):
                 improvement_score = 0.0
             return improvement_score

--- a/vulcanai/models/metrics.py
+++ b/vulcanai/models/metrics.py
@@ -889,7 +889,7 @@ class Metrics(object):
                     valid_interv=valid_interv, plot=plot, save_path=save_path)
                 dct_scores = get_probs(network, val_loader, index_to_iter, ls_feat_vals)
                 dct_filtered = filter_matched_subj(dct_scores, val_loader, index_to_iter)
-                for val in list(dct_filtered):
+                for val in dct_filtered:
                     dct_filteredSubj[val].append(dct_filtered[val])
                     ls_filteredProbs.append(dct_filtered[val])
             V_p = np.array(ls_filteredProbs).mean()

--- a/vulcanai/models/utils.py
+++ b/vulcanai/models/utils.py
@@ -51,6 +51,19 @@ def get_probs(network, loader, index_to_iter, ls_feat_vals):
     return dct_scores
 
 def filter_matched_subj(dct_scores, loader, index_to_iter):
+    """
+    Returns dictionary of filtered keys based on predicted value and value truly assigned in actual set.
+    Parameters:
+        dct_scores : dictionary
+            dictionary of probability scores produced in get_scores function
+        loader : torch.dataloader
+            dataloader containing validation set
+        index_to_iter : string
+            feature to iterate through adjusting values
+    Returns:
+        dct_filtered : dictionary
+            dictionary of filtered entities 
+    """
     dct_filtered = {}
     for subj in list(dct_scores):
         highest_prob = max(dct_scores[subj].values())

--- a/vulcanai/models/utils.py
+++ b/vulcanai/models/utils.py
@@ -33,16 +33,21 @@ def get_probs(network, loader, index_to_iter, ls_feat_vals):
     for index in range(len(loader)):
         dct_scores[index] = {}
     for index in range(len(loader)):
-        nn_subjLabel = torch.LongTensor(loader.dataset[index][1].float().numpy())
-        input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), nn_subjLabel.unsqueeze(0)))
+        # Extract specific index from loader and create a DataLoader instance to send to forward_pass
+        input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), loader.dataset[index][1].unsqueeze(0)))
+        
         subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)
+        # Standardize probability of positive label
         subjProb = subjProb[0][1] * 100
         subjProb = round(subjProb, 2)
+        # Add probability to scores dictionary where keys are the index and value the probability belongs to.
         dct_scores[index][loader.dataset[index][0][index_to_iter].item()] = subjProb
+        # Iterate through other possible values and find probability of positive label and add to dictionary
+        # for current index.
         for newVal in ls_feat_vals:
             if newVal != loader.dataset[index][0][index_to_iter].item():
                 loader.dataset[index][0][index_to_iter] = newVal
-                input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), nn_subjLabel.unsqueeze(0)))
+                input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), loader.dataset[index][1].unsqueeze(0)))
                 subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)
                 subjProb = subjProb[0][1] * 100
                 subjProb = round(subjProb, 2)

--- a/vulcanai/models/utils.py
+++ b/vulcanai/models/utils.py
@@ -33,17 +33,16 @@ def get_probs(network, loader, index_to_iter, ls_feat_vals):
     for index in range(len(loader)):
         dct_scores[index] = {}
     for index in range(len(loader)):
-        nn_subjFeat = torch.Tensor(loader.dataset[index][0].numpy())
         nn_subjLabel = torch.LongTensor(loader.dataset[index][1].float().numpy())
-        input_loader = DataLoader(TensorDataset(nn_subjFeat.unsqueeze(0), nn_subjLabel.unsqueeze(0)))
+        input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), nn_subjLabel.unsqueeze(0)))
         subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)
         subjProb = subjProb[0][1] * 100
         subjProb = round(subjProb, 2)
         dct_scores[index][nn_subjFeat[index_to_iter].item()] = subjProb
         for newVal in ls_feat_vals:
             if newVal != nn_subjFeat[index_to_iter].item():
-                nn_subjFeat[index_to_iter] = newVal
-                input_loader = DataLoader(TensorDataset(nn_subjFeat.unsqueeze(0), nn_subjLabel.unsqueeze(0)))
+                loader.dataset[index][0][index_to_iter] = newVal
+                input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), nn_subjLabel.unsqueeze(0)))
                 subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)
                 subjProb = subjProb[0][1] * 100
                 subjProb = round(subjProb, 2)
@@ -68,9 +67,7 @@ def filter_matched_subj(dct_scores, loader, index_to_iter):
     for subj in list(dct_scores):
         highest_prob = max(dct_scores[subj].values())
         highest_val = [val for val, prob in dct_scores[subj].items() if prob==highest_prob]
-        if len(highest_val) == len(list(dct_scores[subj])):
-             dct_filtered[subj] = highest_prob
-        elif loader.dataset.dataset[subj][0][index_to_iter].item() in highest_val:
+        if loader.dataset.dataset[subj][0][index_to_iter].item() in highest_val:
             dct_filtered[subj] = highest_prob
     return dct_filtered
 

--- a/vulcanai/models/utils.py
+++ b/vulcanai/models/utils.py
@@ -38,9 +38,9 @@ def get_probs(network, loader, index_to_iter, ls_feat_vals):
         subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)
         subjProb = subjProb[0][1] * 100
         subjProb = round(subjProb, 2)
-        dct_scores[index][nn_subjFeat[index_to_iter].item()] = subjProb
+        dct_scores[index][loader.dataset[index][0][index_to_iter].item()] = subjProb
         for newVal in ls_feat_vals:
-            if newVal != nn_subjFeat[index_to_iter].item():
+            if newVal != loader.dataset[index][0][index_to_iter].item():
                 loader.dataset[index][0][index_to_iter] = newVal
                 input_loader = DataLoader(TensorDataset(loader.dataset[index][0].unsqueeze(0), nn_subjLabel.unsqueeze(0)))
                 subjProb = network.forward_pass(data_loader=input_loader, transform_outputs=False)


### PR DESCRIPTION
I did not feel comfortable directly changing to `cross_validate`; so I created a `boot_cv` function that performs similar functionality to `cross_validate`. After it trains it sends the created `val_loader` to `get_probs` in `utils.py` to get the probability of the target for each possible value. Once it gets the scores it goes to `filtered_matched_subj` in `utils.py` and filters by key based on the highest probable output compared to the actual value they had in a "real" dataset. It does this process for every fold specified. Then it calculates the improvement score (`V_p/V_t`) where `V_p` is the mean probability of our filtered dictionary. `V_t` is the rate of the positive value in the label feature.

As of now this can only be used with binary targets, where the positive label is 1. 