### PR TITLE
Selu test fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='vulcanai',
-    version='1.0.2',
+    version='1.0.3',
     description='A high-level framework built on top of Pytorch'
                 ' using added functionality from Scikit-learn to provide '
                 'all of the tools needed for visualizing and processing '

--- a/vulcanai/tests/models/test_layers.py
+++ b/vulcanai/tests/models/test_layers.py
@@ -188,12 +188,13 @@ class TestSeluInit:
         starting_weight = copy.deepcopy(conv_unit._kernel.weight)
         fan_in = conv_unit._kernel.in_channels * \
             reduce(lambda k1, k2: k1 * k2, conv_unit._kernel.kernel_size)
-        std = round(math.sqrt(1. / fan_in), 1)
+        std = math.sqrt(1. / fan_in)
         conv_unit.weight_init = selu_weight_init_
         conv_unit._init_weights()
         new_weight = conv_unit._kernel.weight
         assert (torch.equal(starting_weight, new_weight) is False)
-        assert pytest.approx(round(new_weight.std().item(), 1), 0.1) == std
+        assert (math.isclose(new_weight.std().item(), math.sqrt(1./fan_in), rel_tol=0.01) is True)
+        #assert pytest.approx(round(new_weight.std().item(), 1), 0.1) == std
         assert (int(new_weight.mean().item()) == 0)
 
     def test_dense_selu_bias_change(self, dense_unit):

--- a/vulcanai/tests/models/test_layers.py
+++ b/vulcanai/tests/models/test_layers.py
@@ -194,7 +194,6 @@ class TestSeluInit:
         new_weight = conv_unit._kernel.weight
         assert (torch.equal(starting_weight, new_weight) is False)
         assert (math.isclose(new_weight.std().item(), math.sqrt(1./fan_in), rel_tol=0.01) is True)
-        #assert pytest.approx(round(new_weight.std().item(), 1), 0.1) == std
         assert (int(new_weight.mean().item()) == 0)
 
     def test_dense_selu_bias_change(self, dense_unit):


### PR DESCRIPTION
Fix bug through use of `np.round` in selu weight change test. Since `np.round` was used it sometimes rounded to 0.0 which caused it to fail even if it was technically in the correct range.  Switch to use math.isclose.