### PR TITLE
fix wrong parameters

### DIFF
--- a/vulcanai/models/basenetwork.py
+++ b/vulcanai/models/basenetwork.py
@@ -196,7 +196,7 @@ class BaseNetwork(nn.Module):
                             criter_spec is set to an instance of this class. \
                             Set pred_activation to none or change criter_spec."
                                  )
-            self._final_transform = nn.LogSoftmax(dim=1)
+            self._final_transform = nn.Softmax(dim=1)
 
     @abc.abstractmethod
     def _merge_input_network_outputs(self, inputs):

--- a/vulcanai/models/basenetwork.py
+++ b/vulcanai/models/basenetwork.py
@@ -101,7 +101,8 @@ class BaseNetwork(nn.Module):
         else:
             self.input_networks = input_networks
 
-        self._set_final_layer_parameters(num_classes, pred_activation)
+        self._set_final_layer_parameters(pred_activation=pred_activation,
+                                         criter_spec=criter_spec)
 
         self._num_classes = num_classes
 

--- a/vulcanai/models/basenetwork.py
+++ b/vulcanai/models/basenetwork.py
@@ -196,7 +196,7 @@ class BaseNetwork(nn.Module):
                             criter_spec is set to an instance of this class. \
                             Set pred_activation to none or change criter_spec."
                                  )
-            self._final_transform = nn.Softmax(dim=1)
+            self._final_transform = nn.LogSoftmax(dim=1)
 
     @abc.abstractmethod
     def _merge_input_network_outputs(self, inputs):


### PR DESCRIPTION
@joemehltretter I think this may be causing your problem. Sorry :(  The _set_final_layer_parameters function replaces the line that was previously here https://github.com/Aifred-Health/Vulcan/pull/130/files#diff-09d7ff308ec62ab75a95035d00d6c2fcL732 
, however the parameters passed were incorrect, meaning that nothing ever got transformed at the end. 
@rfratila will also add tests so that something like this would be caught in the future. 